### PR TITLE
main: Show version tag on main screen

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -59,6 +59,14 @@ target_include_directories(xemu-dashboard PRIVATE ${SDL2_INCLUDE_DIRS})
 target_link_libraries(xemu-dashboard PUBLIC ${SDL2_LIBRARIES})
 target_link_directories(xemu-dashboard PUBLIC ${SDL2_LIBRARY_DIRS})
 
+# Bring in the git tag
+execute_process(
+  COMMAND git describe --tags --dirty --always
+  OUTPUT_VARIABLE GIT_VERSION
+  OUTPUT_STRIP_TRAILING_WHITESPACE
+)
+add_compile_definitions(GIT_VERSION="${GIT_VERSION}")
+
 #Post-build commands
 file(MAKE_DIRECTORY ${XBOX_ISO_DIR})
 

--- a/main.c
+++ b/main.c
@@ -20,6 +20,10 @@
 #include "assets/font_roboto.h"
 #include "assets/font_ubuntu_mono.h"
 
+#ifndef GIT_VERSION
+#define GIT_VERSION ""
+#endif
+
 #define NANOPRINTF_IMPLEMENTATION
 #define NANOPRINTF_USE_LARGE_FORMAT_SPECIFIERS       1
 #define NANOPRINTF_USE_FIELD_WIDTH_FORMAT_SPECIFIERS 1
@@ -197,6 +201,10 @@ int main(void)
         snprintf(footer_text, sizeof(footer_text), "FTP Server - %s", ip_address);
         text_draw(body_text_cdata, body_text, footer_text, WINDOW_WIDTH - X_MARGIN - text_calculate_width(body_text_cdata, footer_text),
                   WINDOW_HEIGHT - Y_MARGIN, &text_color);
+
+        // Render the build version
+        text_draw(body_text_cdata, body_text, GIT_VERSION, X_MARGIN,
+                  WINDOW_HEIGHT - Y_MARGIN, &(xgu_texture_tint_t){128,128,128,255});
 
         // Render the actual menu items
         render_menu();


### PR DESCRIPTION
Pulls the release tag and shows in on main display.

This and efa9cfd743deef4642192a64c3cf507fa89f4c84 fixes https://github.com/xemu-project/xemu-dashboard/issues/5

![image](https://github.com/user-attachments/assets/c86a628c-1449-4240-bee8-14ff2afe2981)
