### PR TITLE
menu: Implement dashboard installer

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,6 +33,7 @@ add_executable(xemu-dashboard
     menu_main.c
     menu_system_info.c
     menu_eeprom.c
+    menu_install_dash.c
     dvd_autolaunch.c
     network.c
     text.c

--- a/main.c
+++ b/main.c
@@ -6,6 +6,7 @@
 #include <hal/video.h>
 #include <hal/xbox.h>
 #include <nxdk/mount.h>
+#include <nxdk/path.h>
 #include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -101,6 +102,14 @@ int main(void)
     nxMountDrive('Y', "\\Device\\Harddisk0\\Partition4\\");
     nxMountDrive('Z', "\\Device\\Harddisk0\\Partition5\\");
     nxMountDrive('F', "\\Device\\Harddisk0\\Partition6\\");
+
+    // Mount the root is active xbe to Q:
+    {
+        char targetPath[MAX_PATH];
+        nxGetCurrentXbeNtPath(targetPath);
+        *(strrchr(targetPath, '\\') + 1) = '\0';
+        nxMountDrive('Q', targetPath);
+    }
 
     network_initialise();
     autolaunch_dvd_runner();
@@ -280,8 +289,6 @@ static void render_menu(void)
     // Start at the bottom of the first menu item
     int y = MENU_Y + item_height;
 
-    printf("%d < %d %d < %d, offset %d\n", MENU_Y, selected_y_top, selected_y_bottom,
-           FOOTER_Y - (int)BODY_FONT_SIZE, current_menu->scroll_offset);
     // Scroll the selected item to be in view
     if (selected_y_top < MENU_Y + ITEM_PADDING) {
         current_menu->scroll_offset += (MENU_Y + ITEM_PADDING - selected_y_top + 3) >> 2;

--- a/menu_install_dash.c
+++ b/menu_install_dash.c
@@ -1,0 +1,94 @@
+#include <hal/video.h>
+#include <stdlib.h>
+#include <windows.h>
+#include <xboxkrnl/xboxkrnl.h>
+#include <nxdk/path.h>
+
+#include "main.h"
+
+static void install_dashboard(void)
+{
+    static MenuItem status_message_items[] = {
+        {"Installed successfully", NULL},
+        {"Error installing", NULL}};
+
+    static Menu status_message = {
+        .item = NULL,
+        .item_count = 1,
+        .selected_index = 0,
+        .scroll_offset = 0};
+
+    const char *src = "Q:\\default.xbe";
+    const char *dst = "C:\\xboxdash.xbe";
+    const char *bak = "C:\\xboxdash.xbe.bak";
+
+    SetFileAttributesA(dst, FILE_ATTRIBUTE_NORMAL);
+    SetFileAttributesA(bak, FILE_ATTRIBUTE_NORMAL);
+
+    // Create a backup
+    CopyFile(dst, bak, FALSE);
+
+    if (CopyFile(src, dst, FALSE)) {
+        status_message.item = &status_message_items[0];
+        menu_push(&status_message);
+    } else {
+        status_message.item = &status_message_items[1];
+        menu_push(&status_message);
+    }
+}
+
+static void restore_backuo(void)
+{
+    static MenuItem status_message_items[] = {
+        {"Backup restored successfully", NULL},
+        {"Error restoring backup", NULL}};
+
+    static Menu status_message = {
+        .item = NULL,
+        .item_count = 1,
+        .selected_index = 0,
+        .scroll_offset = 0};
+
+    const char *src = "C:\\xboxdash.xbe.bak";
+    const char *dst = "C:\\xboxdash.xbe";
+
+    SetFileAttributesA(dst, FILE_ATTRIBUTE_NORMAL);
+
+    if (CopyFile(src, dst, FALSE)) {
+        status_message.item = &status_message_items[0];
+        menu_push(&status_message);
+    } else {
+        status_message.item = &status_message_items[1];
+        menu_push(&status_message);
+    }
+}
+
+static void cancel(void)
+{
+    menu_pop();
+}
+
+static MenuItem menu_items[] = {
+    {"Dashboard Installer", NULL},
+    {"Restore backup", restore_backuo},
+    {"Install and overwrite \"C:\\xboxdash.xbe\"?", install_dashboard},
+    {"Cancel", cancel}};
+
+static Menu menu = {
+    .item = menu_items,
+    .item_count = sizeof(menu_items) / sizeof(MenuItem),
+    .selected_index = 0,
+    .scroll_offset = 0};
+
+void menu_install_dash_activate(void)
+{
+    // If this xbe is launched from C:/xboxdash.xbe we disable the installer option
+    char target_path[MAX_PATH];
+    nxGetCurrentXbeNtPath(target_path);
+    printf("target_path: %s\n", target_path);
+    if (strcmp(target_path, "\\Device\\Harddisk0\\Partition2\\xboxdash.xbe") == 0) {
+        menu_items[2].callback = NULL;
+    }
+
+    menu_push(&menu);
+}

--- a/menu_main.c
+++ b/menu_main.c
@@ -9,12 +9,14 @@ static void xbox_exit(void);
 static void xbox_flush_cache(void);
 void menu_system_info_activate(void);
 void menu_eeprom_activate(void);
+void menu_install_dash_activate(void);
 
 static MenuItem menu_items[] = {
     {"Main Menu", NULL},
     {"System Info", menu_system_info_activate},
     {"EEPROM Settings", menu_eeprom_activate},
     {"Clear Cache", xbox_flush_cache},
+    {"Install", menu_install_dash_activate},
     {"Reboot", xbox_exit}};
 
 static Menu menu = {


### PR DESCRIPTION
Add an installer option if loaded from an xiso. It copies the xbe from the xiso and replaces c:\\xboxdash.xbe (this will make it permanent)

It also creates a backup of the previous xboxdash.xbe so you can restore if needed


This is an easy way to update it without replacing the whole qcow image.

Fixes https://github.com/xemu-project/xemu-dashboard/issues/8