### PR TITLE
Cache status

### DIFF
--- a/main.c
+++ b/main.c
@@ -246,7 +246,7 @@ void menu_push(Menu *menu)
 {
     menu_stack[++menu_stack_top] = menu;
     if (menu->selected_index == 0) {
-        menu->selected_index = 1;
+        menu->selected_index = 1 % menu->item_count;
     }
 }
 

--- a/menu_main.c
+++ b/menu_main.c
@@ -95,4 +95,15 @@ static void xbox_flush_cache(void)
 
     // Delete E:\CACHE too
     recursive_empty_folder("E:\\CACHE");
+
+    static MenuItem status_message_items[] = {
+        {"Cache cleared successfully", NULL}};
+
+    static Menu status_message = {
+        .item = status_message_items,
+        .item_count = sizeof(status_message_items) / sizeof(status_message_items),
+        .selected_index = 0,
+        .scroll_offset = 0};
+
+    menu_push(&status_message);
 }


### PR DESCRIPTION
A crash could happen if menus that had a single item

Added cache status message when cleared