### PR TITLE
Add spaced used metric to system info in the dash

### DIFF
--- a/menu_system_info.c
+++ b/menu_system_info.c
@@ -9,7 +9,6 @@
 #define MAX_CHARACTERS 12024
 static char char_pool[MAX_CHARACTERS];
 static int pool_offset;
-static int show_used_space = 1;
 
 typedef struct _PCI_SLOT_NUMBER
 {
@@ -54,16 +53,6 @@ static void callback_stub(void)
 {
 }
 
-static void update_system_info(void);
-
-static void toggle_space_display(void)
-{
-    show_used_space = !show_used_space;
-    WaitForSingleObject(text_render_mutex, INFINITE);
-    update_system_info();
-    ReleaseMutex(text_render_mutex);
-}
-
 static void update_system_info(void)
 {
     int line = 0;
@@ -94,18 +83,10 @@ static void update_system_info(void)
             ULONGLONG total_mib = total_bytes.QuadPart / 1024ULL;
             ULONGLONG mib_available = bytes_available.QuadPart / 1024ULL;
             ULONGLONG mib_used = total_mib - mib_available;
-            ULONGLONG percent_free = (mib_available * 100ULL) / total_mib;
-            ULONGLONG percent_used = 100 - percent_free;
-
-            if (show_used_space) {
-                push_line(line++, callback_stub, "    %c: %llu / %llu MiB (%llu%% used)", drive_letters[i][0], mib_used, total_mib, percent_used);
-            } else {
-                push_line(line++, callback_stub, "    %c: %llu / %llu MiB (%llu%% available)", drive_letters[i][0], mib_available, total_mib, percent_free);
-            }
+            ULONGLONG percent_used = 100 - (mib_available * 100ULL) / total_mib;
+            push_line(line++, callback_stub, "    %c: %llu / %llu MiB (%llu%% used)", drive_letters[i][0], mib_used, total_mib, percent_used);
         }
     }
-
-    push_line(line++, toggle_space_display, show_used_space ? "Press A to show Available Space" : "Press A to show Used Space");
 
     // Active encoder
     static const char *encoder_string = NULL;

--- a/menu_system_info.c
+++ b/menu_system_info.c
@@ -75,17 +75,17 @@ static void update_system_info(void)
     push_line(line++, callback_stub, "CPU Clock: %llu MHz, GPU Clock: %lu MHz\n", cpu_clock.QuadPart / 1000000, gpu_clock);
 
     // Free space on partitions
-    push_line(line++, callback_stub, "Free Space on Partitions:");
+    push_line(line++, callback_stub, "Disk Space Utilized on Partitions:");
     const char *drive_letters[] = {"C:\\", "E:\\", "F:\\", "G:\\", "X:\\", "Y:\\", "Z:\\"};
     for (unsigned int i = 0; i < sizeof(drive_letters) / sizeof(drive_letters[0]); i++) {
         ULARGE_INTEGER bytes_available, total_bytes;
-        if (GetDiskFreeSpaceEx(drive_letters[i], &bytes_available, &total_bytes, NULL)) {
-            ULONGLONG total_mib = total_bytes.QuadPart / 1024ULL;
-            ULONGLONG mib_available = bytes_available.QuadPart / 1024ULL;
-            ULONGLONG mib_used = total_mib - mib_available;
-            ULONGLONG percent_used = 100 - (mib_available * 100ULL) / total_mib;
-            push_line(line++, callback_stub, "    %c: %llu / %llu MiB (%llu%% used)", drive_letters[i][0], mib_used, total_mib, percent_used);
-        }
+    if (GetDiskFreeSpaceEx(drive_letters[i], &bytes_available, &total_bytes, NULL)) {
+        ULONGLONG total_mib = total_bytes.QuadPart / 1024ULL;
+        ULONGLONG mib_available = bytes_available.QuadPart / 1024ULL;
+        ULONGLONG mib_used = (mib_available <= total_mib) ? (total_mib - mib_available) : 0;
+        ULONGLONG percent_used = (total_mib > 0) ? (100 - (mib_available * 100ULL) / total_mib) : 100;
+        push_line(line++, callback_stub, "    %c: %llu / %llu MiB (%llu%% used)", drive_letters[i][0], mib_used, total_mib, percent_used);
+    }
     }
 
     // Active encoder

--- a/menu_system_info.c
+++ b/menu_system_info.c
@@ -9,6 +9,7 @@
 #define MAX_CHARACTERS 12024
 static char char_pool[MAX_CHARACTERS];
 static int pool_offset;
+static int show_used_space = 1;
 
 typedef struct _PCI_SLOT_NUMBER
 {
@@ -53,6 +54,14 @@ static void callback_stub(void)
 {
 }
 
+static void toggle_space_display(void)
+{
+    show_used_space = !show_used_space;
+    WaitForSingleObject(text_render_mutex, INFINITE);
+    update_system_info();
+    ReleaseMutex(text_render_mutex);
+}
+
 static void update_system_info(void)
 {
     int line = 0;
@@ -82,10 +91,19 @@ static void update_system_info(void)
         if (GetDiskFreeSpaceEx(drive_letters[i], &bytes_available, &total_bytes, NULL)) {
             ULONGLONG total_mib = total_bytes.QuadPart / 1024ULL;
             ULONGLONG mib_available = bytes_available.QuadPart / 1024ULL;
+            ULONGLONG mib_used = total_mib - mib_available;
             ULONGLONG percent_free = (mib_available * 100ULL) / total_mib;
-            push_line(line++, callback_stub, "    %c: %llu / %llu MiB (%llu%%)", drive_letters[i][0], mib_available, total_mib, percent_free);
+            ULONGLONG percent_used = 100 - percent_free;
+
+            if (show_used_space) {
+                push_line(line++, callback_stub, "    %c: %llu / %llu MiB (%llu%% used)", drive_letters[i][0], mib_used, total_mib, percent_used);
+            } else {
+                push_line(line++, callback_stub, "    %c: %llu / %llu MiB (%llu%% available)", drive_letters[i][0], mib_available, total_mib, percent_free);
+            }
         }
     }
+
+    push_line(line++, toggle_space_display, show_used_space ? "Press A to show Available Space" : "Press A to show Used Space");
 
     // Active encoder
     static const char *encoder_string = NULL;

--- a/menu_system_info.c
+++ b/menu_system_info.c
@@ -75,17 +75,17 @@ static void update_system_info(void)
     push_line(line++, callback_stub, "CPU Clock: %llu MHz, GPU Clock: %lu MHz\n", cpu_clock.QuadPart / 1000000, gpu_clock);
 
     // Free space on partitions
-    push_line(line++, callback_stub, "Disk Space Utilized on Partitions:");
+    push_line(line++, callback_stub, "Disk Utilization:");
     const char *drive_letters[] = {"C:\\", "E:\\", "F:\\", "G:\\", "X:\\", "Y:\\", "Z:\\"};
     for (unsigned int i = 0; i < sizeof(drive_letters) / sizeof(drive_letters[0]); i++) {
         ULARGE_INTEGER bytes_available, total_bytes;
-    if (GetDiskFreeSpaceEx(drive_letters[i], &bytes_available, &total_bytes, NULL)) {
-        ULONGLONG total_mib = total_bytes.QuadPart / 1024ULL;
-        ULONGLONG mib_available = bytes_available.QuadPart / 1024ULL;
-        ULONGLONG mib_used = (mib_available <= total_mib) ? (total_mib - mib_available) : 0;
-        ULONGLONG percent_used = (total_mib > 0) ? (100 - (mib_available * 100ULL) / total_mib) : 100;
-        push_line(line++, callback_stub, "    %c: %llu / %llu MiB (%llu%% used)", drive_letters[i][0], mib_used, total_mib, percent_used);
-    }
+        if (GetDiskFreeSpaceEx(drive_letters[i], &bytes_available, &total_bytes, NULL)) {
+            ULONGLONG total_mib = total_bytes.QuadPart / 1024ULL;
+            ULONGLONG mib_available = bytes_available.QuadPart / 1024ULL;
+            ULONGLONG mib_used = (mib_available <= total_mib) ? (total_mib - mib_available) : 0;
+            ULONGLONG percent_used = (total_mib > 0) ? (100 - (mib_available * 100ULL) / total_mib) : 100;
+            push_line(line++, callback_stub, "    %c: %llu / %llu MiB (%llu%% used)", drive_letters[i][0], mib_used, total_mib, percent_used);
+        }
     }
 
     // Active encoder

--- a/menu_system_info.c
+++ b/menu_system_info.c
@@ -54,6 +54,8 @@ static void callback_stub(void)
 {
 }
 
+static void update_system_info(void);
+
 static void toggle_space_display(void)
 {
     show_used_space = !show_used_space;


### PR DESCRIPTION
This came up as part of a conversation with a user where it wasn't incredibly clear as to the used space on their drive, and it was a fair point given a lot of tools do show that metric in the form of used space, instead of available space, and I think it does appear better formatted that way.

<img width="1918" height="1015" alt="image" src="https://github.com/user-attachments/assets/57416f2a-d9cd-4d4a-a4a6-64509a398bdb" />

I initially wanted to ditch the space available part entirely, but I figured that I'd add it as a toggle that way it'd be more likely to be accepted :p

<img width="1918" height="1015" alt="image" src="https://github.com/user-attachments/assets/ece9c5d0-03ab-4171-aa5d-aa59f46bc527" />
