### PR TITLE
build.yml: Update Action Versions/Silence Node Warnings

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ jobs:
         pip3 install pyfatx libqcow-python
 
     - name: Checkout Repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         submodules: recursive
         fetch-depth: 0
@@ -92,14 +92,14 @@ jobs:
         } > artifact/LICENSE
 
     - name: Upload artifact
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: xemu-dashboard
         path: artifact
 
     - name: Create GitHub Release
       if: github.event_name == 'push' && github.ref == 'refs/heads/master'
-      uses: softprops/action-gh-release@v2
+      uses: softprops/action-gh-release@v3
       with:
         tag_name: ${{ steps.release_tag.outputs.tag }}
         name: "Build ${{ steps.release_tag.outputs.tag }}"


### PR DESCRIPTION
This is intended to silence the node warnings that Actions using Node 20 are set to be deprecated and stop working in favor of Node 24 due to security related issues. This bumps the versions of the Actions used to silence that warning, as well as the 1 other Action that doesn't use Node, as it also has a version update.

I don't think this subrepo from the xemu proj is rapidly developed enough to need the extra PR bloat from dependabot for 3 modules, tbh